### PR TITLE
Improve service stop order

### DIFF
--- a/usr/lib/systemd/system/chupa-text.service
+++ b/usr/lib/systemd/system/chupa-text.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=ChupaText - Text extraction service
-After=network.target
+After=network.target docker.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
chupa-text service fails stop if docker.service stop before stop of chupa-text service.
Because chupa-text service execute "docker-compose down" when chupa-text service stop.